### PR TITLE
improve error message

### DIFF
--- a/src/blog/model/MatrixSpec.java
+++ b/src/blog/model/MatrixSpec.java
@@ -63,7 +63,7 @@ public class MatrixSpec extends ArgSpec {
     for (int i = 0; i < num_rows; i++) {
       List<ArgSpec> rowList = ((ListSpec) values.get(i)).elements;
       if (rowList.size() != num_cols) {
-        Util.fatalError("Matrix is not square!");
+        Util.fatalError("Matrix rows have unequal length.");
       }
 
       for (int j = 0; j < num_cols; j++) {


### PR DESCRIPTION
@lileicc 

Tiny change, ready for review.

The error is not that the matrix isn't square, but that its rows don't all have the same length.

Example model to test the error:

```
fixed RealMatrix x = [1.0, 2.0; 3.0; 4.0];
query x;
```

Currently this produces:

```
Using fixed random seed for repeatability.
Fatal error: Matrix rows have unequal length.
java.lang.Exception: Stack trace
    at java.lang.Thread.dumpStack(Thread.java:1364)
    at blog.common.Util.fatalError(Util.java:545)
    at blog.common.Util.fatalError(Util.java:528)
    at blog.model.MatrixSpec.getValues2D(MatrixSpec.java:66)
    at blog.model.MatrixSpec.getValues(MatrixSpec.java:51)
    at blog.model.MatrixSpec.compile(MatrixSpec.java:107)
    at blog.model.NonRandomFunction.initInterp(NonRandomFunction.java:336)
    at blog.model.NonRandomFunction.compile(NonRandomFunction.java:323)
    at blog.model.Model.compile(Model.java:566)
    at blog.Main.setup(Main.java:607)
    at blog.Main.main(Main.java:171)
Exception in thread "main" java.lang.IndexOutOfBoundsException: Index: 1, Size: 1
    at java.util.ArrayList.rangeCheck(ArrayList.java:635)
    at java.util.ArrayList.get(ArrayList.java:411)
    at blog.model.MatrixSpec.getValues2D(MatrixSpec.java:70)
    at blog.model.MatrixSpec.getValues(MatrixSpec.java:51)
    at blog.model.MatrixSpec.compile(MatrixSpec.java:107)
    at blog.model.NonRandomFunction.initInterp(NonRandomFunction.java:336)
    at blog.model.NonRandomFunction.compile(NonRandomFunction.java:323)
    at blog.model.Model.compile(Model.java:566)
    at blog.Main.setup(Main.java:607)
    at blog.Main.main(Main.java:171)
```

**Is there a way to catch this at parse time and provide line and column number?**
