### PR TITLE
added size buildin function

### DIFF
--- a/src/blog/model/BuiltInFunctions.java
+++ b/src/blog/model/BuiltInFunctions.java
@@ -392,7 +392,8 @@ public class BuiltInFunctions {
   public static FixedFunction SET_SUM;
 
   /**
-   * Take a Set x of Real values, and return the sum of its elements.
+   * Take a Set x of values (any type, including user declared type), and return
+   * the number of elements in the Set.
    */
   public static FixedFunction SET_SIZE;
 


### PR DESCRIPTION
The following example is working:

```
type Person;
distinct Person P[100];
#Person ~ Poisson(10);
query size({p for Person p});
```

But this example is not

```
query size({1, 2, 3});
```

It is due to ExplicitSetSpec. will be fixed in a seperate issue/pr.

@cberzan 
ready for review.
