### PR TITLE
tools to automatically update github pages

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,10 @@ lazy val html = taskKey[Unit]("Generate html documentation")
 
 html := { """pelican docs/content -o target/pelican -s docs/pelicanconf.py""" ! }
 
+lazy val ghpages = taskKey[Unit]("Push updated html docs to github pages")
+
+ghpages := { """docs/update_ghpages.sh""" ! }
+
 lazy val parser = taskKey[Unit]("Generating parser files")
 
 lazy val lexer = taskKey[Unit]("Generating lexer files")

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -8,23 +8,6 @@ OUTPUTDIR=$(BASEDIR)/output
 CONFFILE=$(BASEDIR)/pelicanconf.py
 PUBLISHCONF=$(BASEDIR)/publishconf.py
 
-FTP_HOST=localhost
-FTP_USER=anonymous
-FTP_TARGET_DIR=/
-
-SSH_HOST=localhost
-SSH_PORT=22
-SSH_USER=root
-SSH_TARGET_DIR=/var/www
-
-S3_BUCKET=my_s3_bucket
-
-CLOUDFILES_USERNAME=my_rackspace_username
-CLOUDFILES_API_KEY=my_rackspace_api_key
-CLOUDFILES_CONTAINER=my_cloudfiles_container
-
-DROPBOX_DIR=~/Dropbox/Public/
-
 DEBUG ?= 0
 ifeq ($(DEBUG), 1)
 	PELICANOPTS += -D
@@ -41,13 +24,6 @@ help:
 	@echo '   make serve [PORT=8000]           serve site at http://localhost:8000'
 	@echo '   make devserver [PORT=8000]       start/restart develop_server.sh    '
 	@echo '   make stopserver                  stop local server                  '
-	@echo '   make ssh_upload                  upload the web site via SSH        '
-	@echo '   make rsync_upload                upload the web site via rsync+ssh  '
-	@echo '   make dropbox_upload              upload the web site via Dropbox    '
-	@echo '   make ftp_upload                  upload the web site via FTP        '
-	@echo '   make s3_upload                   upload the web site via S3         '
-	@echo '   make cf_upload                   upload the web site via Cloud Files'
-	@echo '   make github                      upload the web site via gh-pages   '
 	@echo '                                                                       '
 	@echo 'Set the DEBUG variable to 1 to enable debugging, e.g. make DEBUG=1 html'
 	@echo '                                                                       '
@@ -83,26 +59,4 @@ stopserver:
 publish:
 	$(PELICAN) $(INPUTDIR) -o $(OUTPUTDIR) -s $(PUBLISHCONF) $(PELICANOPTS)
 
-ssh_upload: publish
-	scp -P $(SSH_PORT) -r $(OUTPUTDIR)/* $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR)
-
-rsync_upload: publish
-	rsync -e "ssh -p $(SSH_PORT)" -P -rvz --delete $(OUTPUTDIR)/ $(SSH_USER)@$(SSH_HOST):$(SSH_TARGET_DIR) --cvs-exclude
-
-dropbox_upload: publish
-	cp -r $(OUTPUTDIR)/* $(DROPBOX_DIR)
-
-ftp_upload: publish
-	lftp ftp://$(FTP_USER)@$(FTP_HOST) -e "mirror -R $(OUTPUTDIR) $(FTP_TARGET_DIR) ; quit"
-
-s3_upload: publish
-	s3cmd sync $(OUTPUTDIR)/ s3://$(S3_BUCKET) --acl-public --delete-removed
-
-cf_upload: publish
-	cd $(OUTPUTDIR) && swift -v -A https://auth.api.rackspacecloud.com/v1.0 -U $(CLOUDFILES_USERNAME) -K $(CLOUDFILES_API_KEY) upload -c $(CLOUDFILES_CONTAINER) .
-
-github: publish
-	ghp-import $(OUTPUTDIR)
-	git push origin gh-pages
-
-.PHONY: html help clean regenerate serve devserver publish ssh_upload rsync_upload dropbox_upload ftp_upload s3_upload cf_upload github
+.PHONY: html help clean regenerate serve devserver publish

--- a/docs/update_ghpages.sh
+++ b/docs/update_ghpages.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Updates the github-pages repo with the latest docs.
+# Expects to be executed from the blog root dir.
+# Expects the github-pages repo to be in the following dir:
+GHPAGES_DIR=../bayesianlogic.github.io
+
+set -e
+
+COMMITHASH=$(git rev-parse HEAD)
+rm -r $GHPAGES_DIR/*
+(cd docs; make html)
+cp -r docs/output/* $GHPAGES_DIR/
+cd $GHPAGES_DIR
+git add --all
+git commit -m "generated docs from blog commit ${COMMITHASH}"
+git push origin master


### PR DESCRIPTION
@lileicc 

Docs now live at http://bayesianlogic.github.io/.

To update the docs, you can use "sbt/sbt ghpages".

Note that the bayesianlogic.github.io repo has to be cloned in the same parent dir as the blog repo, e.g. `~/blog` and `~/bayesianlogic.github.io`.
