### PR TITLE
Change the Java heap size for sbt.bat

### DIFF
--- a/sbt/sbt
+++ b/sbt/sbt
@@ -1,2 +1,2 @@
-SBT_OPTS="-Xms512M -Xmx1536M -Xss1M -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M"
+SBT_OPTS="-XX:+CMSClassUnloadingEnabled"
 java $SBT_OPTS -jar `dirname $0`/sbt-launch.jar "$@"

--- a/sbt/sbt.bat
+++ b/sbt/sbt.bat
@@ -1,2 +1,2 @@
 set SCRIPT_DIR=%~dp0
-java -XX:+CMSClassUnloadingEnabled -XX:MaxPermSize=256M -jar "%SCRIPT_DIR%sbt-launch.jar" %*
+java -XX:+CMSClassUnloadingEnabled -jar "%SCRIPT_DIR%sbt-launch.jar" %*


### PR DESCRIPTION
@lileicc Change the Java heap size for sbt/sbt.bat so that it could work for 32-bit Operating System.
