### PR TITLE
make sure there are at least 2 components

### DIFF
--- a/example/background/adaptive-background-mixture.dblog
+++ b/example/background/adaptive-background-mixture.dblog
@@ -20,7 +20,7 @@
 
 type Component;
 
-#Component ~ UniformInt(1, 15);
+#Component ~ UniformInt(2, 15);
 
 random RealMatrix Weight ~ Dirichlet(0.2 * ones(size({c for Component c}), 1));
 


### PR DESCRIPTION
If there's only one component, we can't initialize the Dirichlet
distribution, because the parameter is a 1x1 matrix.

CC @chrisgioia64 
